### PR TITLE
Fixes #31 rSharp_create_domain need an argument for library location …

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,12 +75,6 @@ loadAndInit <- function(chname, pkgname, libname, srcPkgLibPath=NULL) {
     # srcPkgLibPath ends with platform separator (e.g. '/')
     f <- file.path(srcPkgLibPath, paste0(chname, ext))
 
-    # save current working directory
-    og_wd <- getwd()
-
-    # change working directory to load libs
-    message("Temporary working directory:", srcPkgLibPath)
-    setwd(srcPkgLibPath)
     dyn.load(f)
 
   } else {
@@ -91,11 +85,6 @@ loadAndInit <- function(chname, pkgname, libname, srcPkgLibPath=NULL) {
   clrInit(debug_flag!="")
   appendStartupMsg(paste('Loaded Common Language Runtime version', getClrVersionString()))
   setRDotNet(TRUE)
-
-  if (exists("og_wd")) {
-    # restore the original working directory
-    setwd(og_wd)
-  }
 }
 
 appendStartupMsg <- function(msg) {

--- a/src/Makefile.win.in
+++ b/src/Makefile.win.in
@@ -15,7 +15,6 @@ DOTNET_CMD=dotnet
 MSB=@MSBUILD_EXE_PATH@
 
 INSTDIR= ../inst
-NETHOST=nethost
 RUNTIMECONFIG=RSharp.runtimeconfig
 
 # This can be helpful to diagnose the msbuild procedure
@@ -81,7 +80,6 @@ rSharpLib: rSharpLibComp
 	$(ROBOCP_CMD) $$bin_dir $(INSTDIR)/libs/ $$RSHARPBINS;\
 	
 	
-	$(ROBOCP_CMD) ./packages/Microsoft.NETCore.App.Host.win-x64.8.0.2/runtimes/win-x64/native $(INSTDIR)/libs/ $(NETHOST).dll
 	$(ROBOCP_CMD) ./ $(INSTDIR)/libs/ $(RUNTIMECONFIG).json;
 	-$(ROBOCP_CMD) ./ClrFacade/bin/$(BuildConfiguration)/net8.0/ $(INSTDIR)/libs/ $(CLR_FACADE_BINS)
 	-$(ROBOCP_CMD) ./ClrFacade/bin/$(BuildConfiguration)/net8.0/ $(INSTDIR)/libs/ $(RDOTNET_BINS)

--- a/src/rSharp.cpp
+++ b/src/rSharp.cpp
@@ -38,16 +38,6 @@ void freeObject(RSharpGenericValue* instance);
 /////////////////////////////////////////
 void rSharp_create_domain(char ** libraryPath)
 {
-	size_t lengthInWideFormat = 0;
-	//Gets the length of libPath in terms of a wide string.
-	mbstowcs_s(&lengthInWideFormat, nullptr, 0, *libraryPath, 0);
-	wchar_t* wideStringLibraryPath = new wchar_t[lengthInWideFormat + 1];
-	//Copies the libraryPath to a wchar_t with the size lengthInWideFormat
-	mbstowcs_s(nullptr, wideStringLibraryPath, lengthInWideFormat + 1, *libraryPath, lengthInWideFormat);
-
-	wchar_t* wideStringPath = MergeLibraryPath(wideStringLibraryPath, STR("/RSharp.runtimeconfig.json"));
-	dotnetlib_path = MergeLibraryPath(wideStringLibraryPath, STR("/ClrFacade.dll"));
-
 	// if already loaded in this process, do not load again
 	if (load_assembly_and_get_function_pointer != nullptr)
 		return;
@@ -60,6 +50,16 @@ void rSharp_create_domain(char ** libraryPath)
 	}
 
 	// STEP 2: Initialize and start the .NET Core runtime
+	size_t lengthInWideFormat = 0;
+	//Gets the length of libPath in terms of a wide string.
+	mbstowcs_s(&lengthInWideFormat, nullptr, 0, *libraryPath, 0);
+	wchar_t* wideStringLibraryPath = new wchar_t[lengthInWideFormat + 1];
+	//Copies the libraryPath to a wchar_t with the size lengthInWideFormat
+	mbstowcs_s(nullptr, wideStringLibraryPath, lengthInWideFormat + 1, *libraryPath, lengthInWideFormat);
+
+	wchar_t* wideStringPath = MergeLibraryPath(wideStringLibraryPath, STR("/RSharp.runtimeconfig.json"));
+	dotnetlib_path = MergeLibraryPath(wideStringLibraryPath, STR("/ClrFacade.dll"));
+
 	load_assembly_and_get_function_pointer = nullptr;
 	load_assembly_and_get_function_pointer = get_dotnet_load_assembly(wideStringPath);
 	assert(load_assembly_and_get_function_pointer != nullptr && "Failure: get_dotnet_load_assembly()");

--- a/src/rSharp.cpp
+++ b/src/rSharp.cpp
@@ -9,7 +9,7 @@
 
 using string_t = std::basic_string<char_t>;
 
-const string_t dotnetlib_path = STR("./ClrFacade.dll");
+const char_t* dotnetlib_path = nullptr;
 const auto loadAssemblyDelegate = STR("ClrFacade.ClrFacade+LoadFromDelegate, ClrFacade");
 void* create_instance_fn_ptr = nullptr;
 void* load_from_fn_ptr = nullptr;
@@ -38,6 +38,9 @@ void freeObject(RSharpGenericValue* instance);
 /////////////////////////////////////////
 void rSharp_create_domain(char ** libPath)
 {
+	char_t* wideStringPath = MergeLibPath(libPath, "/RSharp.runtimeconfig.json");
+	dotnetlib_path = MergeLibPath(libPath, "/ClrFacade.dll");
+
 	// if already loaded in this process, do not load again
 	if (load_assembly_and_get_function_pointer != nullptr)
 		return;
@@ -50,9 +53,15 @@ void rSharp_create_domain(char ** libPath)
 	}
 
 	// STEP 2: Initialize and start the .NET Core runtime
+	load_assembly_and_get_function_pointer = nullptr;
+	load_assembly_and_get_function_pointer = get_dotnet_load_assembly(wideStringPath);
+	assert(load_assembly_and_get_function_pointer != nullptr && "Failure: get_dotnet_load_assembly()");
 
-	const char* additionalPath = "/RSharp.runtimeconfig.json";
+	delete[] wideStringPath;
+}
 
+char_t* MergeLibPath(char** libPath, char* additionalPath)
+{
 	size_t libPathLen = strlen(*libPath);
 	size_t additionalPathLen = strlen(additionalPath);
 
@@ -66,12 +75,8 @@ void rSharp_create_domain(char ** libPath)
 	char_t* wideStringPath = new char_t[length + 1];
 	mbstowcs_s(nullptr, wideStringPath, length + 1, combinedPath, length);
 
-	load_assembly_and_get_function_pointer = nullptr;
-	load_assembly_and_get_function_pointer = get_dotnet_load_assembly(wideStringPath);
-	assert(load_assembly_and_get_function_pointer != nullptr && "Failure: get_dotnet_load_assembly()");
-
 	delete[] combinedPath;
-	delete[] wideStringPath;
+	return wideStringPath;
 }
 
 void rSharp_shutdown_clr()
@@ -197,7 +202,7 @@ void initializeCreateInstance()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+CreateInstanceDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("CreateInstance"),
 		functionDelegate,//delegate_type_name
@@ -213,7 +218,7 @@ void initializeLoadAssembly()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+LoadFromDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("LoadFrom"),
 		loadAssemblyDelegate,//delegate_type_name
@@ -229,7 +234,7 @@ void initializeGetFullTypeNameFunction()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+GetObjectTypeNameDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("GetObjectTypeName"),
 		functionDelegate,//delegate_type_name
@@ -245,7 +250,7 @@ void initializeGetObjectDirectFunction()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+CurrentObjectDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("CurrentObject"),
 		functionDelegate,//delegate_type_name
@@ -261,7 +266,7 @@ void initializeCreateSEXPFunction()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+CreateSexpWrapperDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("CreateSexpWrapperLong"),
 		functionDelegate,//delegate_type_name
@@ -278,7 +283,7 @@ void initializeCallInstanceFunction()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+CallInstanceMethodDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("CallInstanceMethod"),
 		functionDelegate,//delegate_type_name
@@ -294,7 +299,7 @@ void initializeFreeObjectFunction()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+FreeObjectDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("FreeObject"),
 		functionDelegate,//delegate_type_name
@@ -311,7 +316,7 @@ void initializeCallStaticFunction()
 	auto functionDelegate = STR("ClrFacade.ClrFacade+CallStaticMethodDelegate, ClrFacade");
 
 	int rc_1 = load_assembly_and_get_function_pointer(
-		dotnetlib_path.c_str(),
+		dotnetlib_path,
 		dotnet_type,
 		STR("CallStaticMethod"),
 		functionDelegate,//delegate_type_name

--- a/src/rSharp.h
+++ b/src/rSharp.h
@@ -144,7 +144,6 @@ extern "C" {
 RSharpGenericValue ConvertToRSharpGenericValue(SEXP s);
 RSharpGenericValue** sexp_to_parameters(SEXP args);
 SEXP ConvertToSEXP(RSharpGenericValue& value);
-char_t* MergeLibPath(char** libPath, char* additionalPath);
 
 
 #ifndef  __cplusplus

--- a/src/rSharp.h
+++ b/src/rSharp.h
@@ -132,7 +132,7 @@ extern "C" {
 	 */
 	void get_FullTypeName( SEXP p, char ** tname);
 	void rSharp_load_assembly(char ** filename);
-	void rSharp_create_domain();
+	void rSharp_create_domain(char** libPath);
 	int use_rdotnet = 0;
 
 

--- a/src/rSharp.h
+++ b/src/rSharp.h
@@ -144,6 +144,7 @@ extern "C" {
 RSharpGenericValue ConvertToRSharpGenericValue(SEXP s);
 RSharpGenericValue** sexp_to_parameters(SEXP args);
 SEXP ConvertToSEXP(RSharpGenericValue& value);
+char_t* MergeLibPath(char** libPath, char* additionalPath);
 
 
 #ifndef  __cplusplus

--- a/src/rSharp.vcxproj
+++ b/src/rSharp.vcxproj
@@ -241,16 +241,17 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);MS_CLR;MS_CLR_TLB;USE_COR_RUNTIME_HOST;WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);MS_CLR;MS_CLR_TLB;USE_COR_RUNTIME_HOST;WINDOWS</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <AdditionalOptions>/TP %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>NotSet</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Rdll.lib;packages\Microsoft.NETCore.App.Host.win-x64.8.0.2\runtimes\win-x64\native\nethost.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Rdll.lib;packages\Microsoft.NETCore.App.Host.win-x64.8.0.2\runtimes\win-x64\native\libnethost.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <ModuleDefinitionFile>rSharp-win.def</ModuleDefinitionFile>
@@ -300,12 +301,13 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);MS_CLR;MS_CLR_TLB;USE_COR_RUNTIME_HOST;WINDOWS</PreprocessorDefinitions>
       <AdditionalOptions>/TP %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>packages\Microsoft.NETCore.App.Host.win-x64.8.0.2\runtimes\win-x64\native\nethost.lib;Rdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>packages\Microsoft.NETCore.App.Host.win-x64.8.0.2\runtimes\win-x64\native\libnethost.lib;Rdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>rSharp-win.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Fixes #31 rSharp_create_domain need an argument for library location 
Fixes #30 Statically link nethost in Windows
Update code to allow the path for the library to be passed from R to the C++ code. 
