### PR TITLE
Not requiring successful dependent jobs

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -28,11 +28,12 @@ jobs:
     if: ${{ needs.changes.outputs.Csharp == 'true' }}
     uses: ./.github/workflows/build-c#.yaml
   R-CMD-Check:
+    if: ${{ always() }}
     needs: build-Csharp-binaries
     uses: ./.github/workflows/R-CMD-check.yaml
   test-coverage:
-    needs: [build-Csharp-binaries, R-CMD-Check]
+    needs: [R-CMD-Check]
     uses:  ./.github/workflows/test-coverage.yaml
   pkgdown:
-    needs: [build-Csharp-binaries, R-CMD-Check]
+    needs: [R-CMD-Check]
     uses:  ./.github/workflows/pkgdown.yaml

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -2,8 +2,6 @@ name: PR-Workflow
 
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 


### PR DESCRIPTION
- Triggers PR workflow on any branch
- Still perform R workflow jobs even if C# binaries builds are skiped