### PR TITLE
Use dotnet8 token in SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     knitr,
     rmarkdown
 License: file LICENSE
-SystemRequirements: .NET (>= 8.0)
+SystemRequirements: dotnet8
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rSharp (development version)
 
-- Declared `.NET (>= 8.0)` in the `SystemRequirements` field of `DESCRIPTION` (#177).
+- Declared `dotnet8` in the `SystemRequirements` field of `DESCRIPTION` (#177).
 - Fixed package failing to load on R 4.6 with `undefined symbol: EXTPTR_PTR` by switching the C++ shim to the stable `R_ExternalPtrAddr()` API.
 - Fixed macOS install-time segfault for users with multiple R versions installed in parallel by removing the versioned `R.framework` path baked into the shipped `.so`. The macOS link line now uses `-undefined dynamic_lookup` instead of `-lR`, matching the convention used by other R packages with C++ code.
 - Arrays of .NET objects are now supported as arguments to methods. However, the signature of the .NET method must accept `Object[]` as parameter type.


### PR DESCRIPTION
## Summary

- Replaces `.NET (>= 8.0)` with `dotnet8` in `DESCRIPTION` to match the upstream sysreqs rule shape proposed in rstudio/r-system-requirements#241.
- The `(>= X)` version tag in `SystemRequirements` is not parsed by the resolver — only the matched token decides which package gets installed. Using a versioned token (`dotnet8`, like `python3` / `java8`) lets future .NET runtimes ship as separate rules without breaking consumers pinned to 8.

## Dependency

Blocked on rstudio/r-system-requirements#241 (the rule itself). Until that merges and propagates to r-hub / Posit Public Package Manager, the `dotnet8` token resolves to nothing and no system package is installed for users on Linux. Keeping this PR as a draft until the upstream rule lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system requirements specification in package metadata, replacing the explicit `.NET (>= 8.0)` notation with the `dotnet8` shorthand for clearer and more consistent system requirement communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->