### PR TITLE
Fix skipped dev version bump and migrate to description_manager

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -29,11 +29,16 @@ jobs:
     if: ${{ needs.detect-changes.outputs.Csharp == 'true' && github.event_name == 'pull_request'}}
     uses: ./.github/workflows/build-c#.yaml
 
-  # Automatically bump dev version when a it is a push to main branch
-  bump-dev-version:
+  # Automatically manage DESCRIPTION on push to main (dev version bump,
+  # toggle @*release in Remotes, tag on release versions).
+  description-manager:
     needs: build-Csharp-binaries
-    if: github.event_name != 'pull_request' # only when merging in main/develop branch
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump_dev_version_tag_branch.yaml@main
+    # `needs` only declares ordering; `!cancelled()` lets this job run even when
+    # build-Csharp-binaries is skipped (which is the normal case on push to main).
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/description_manager.yaml@main
+    # `main` is protected; pass GitHub App credentials so the workflow can push
+    # the DESCRIPTION update and release tags via a bypass-listed app token.
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:
@@ -41,7 +46,7 @@ jobs:
 
   R-CMD-Check:
     if: ${{ !cancelled() }}
-    needs: bump-dev-version
+    needs: description-manager
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
     with:
       os-matrix: '[{"os": "macos-latest", "r": "release"}, {"os": "macos-15-intel", "r": "release"}, {"os": "windows-latest", "r": "release"}, {"os": "ubuntu-latest", "r": "release"}]'


### PR DESCRIPTION
The dev version bump job was silently skipped on push to main (e.g. [run 25736955253](https://github.com/Open-Systems-Pharmacology/rSharp/actions/runs/25736955253)) because it depended on `build-Csharp-binaries`, which is gated to `pull_request` events. When a needed job is skipped, dependents are also skipped unless `if:` explicitly accepts that result. This PR fixes the ordering condition and at the same time migrates the bump job to the recommended replacement reusable workflow.

## Description manager migration

Replace the deprecated `bump_dev_version_tag_branch.yaml` reusable workflow with `description_manager.yaml`, which performs the same job (dev version bump, `@*release` toggle in `Remotes`, tag on release versions) via a tested helper script and a richer step summary. The GitHub App credentials (`VERSION_BUMPER_APPID` / `VERSION_BUMPER_SECRET`) are kept because `main` is a protected branch; with [Open-Systems-Pharmacology/Workflows#227](https://github.com/Open-Systems-Pharmacology/Workflows/pull/227), `description_manager.yaml` accepts those inputs and mints a bypass-listed token via `actions/create-github-app-token@v3`.

## Cascading-skip fix

The job now uses `if: !cancelled() && github.event_name != 'pull_request'` instead of just `github.event_name != 'pull_request'`. `needs:` continues to enforce ordering, but `!cancelled()` lets the job run even when `build-Csharp-binaries` resolves to `skipped`, which is the normal case on push to main. `R-CMD-Check` is rewired to `needs: description-manager` so it picks up the bumped commit.
