### PR TITLE
Install nuget on macOS-Build (arm64) runner

### DIFF
--- a/.github/workflows/build-c#.yaml
+++ b/.github/workflows/build-c#.yaml
@@ -68,6 +68,12 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Install Mono (needed by nuget CLI)
+        run: brew install mono
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v4
+
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
## Summary

The `macOS-Build` (arm64) job in `build-c#.yaml` was failing every PR that touched `shared/**` with:

```
fatal error: 'nethost.h' file not found
   18 | #include <nethost.h>
make: *** [obj/rSharp.o] Error 1
```

The arm64 job was missing the two preparation steps that `macOS-Build-x64` already has:

- `brew install mono`
- `nuget/setup-nuget@v4`

The Makefile's `rSharpNugetRestore` target runs `nuget restore packages.config -PackagesDirectory packages` to populate `packages/Microsoft.NETCore.App.Host.osx-arm64.8.0.2/`, which is the only source of the include path used for `<nethost.h>`. With `nuget` missing from PATH the restore silently failed (the leading `-` in `-$(NUGET_CMD)` swallows the error) and the next `make` step failed at compile time.

The x64 runner is pinned to `macos-15-intel` (an older image) which already had the prerequisites; the arm64 runner uses the org-default `${{ vars.GHA_DEFAULT_RUNNER_MACOS }}` (presumably `macos-latest`), which is a newer, cleaner image where the missing setup is now exposed.

## Change

Add the two missing steps to `macOS-Build`, identical to what `macOS-Build-x64` already does, placed between `Setup .NET` and `Setup R`. Net diff: +6 lines.

```diff
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
+
+      - name: Install Mono (needed by nuget CLI)
+        run: brew install mono
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v4

       - name: Setup R
```

Discovered while investigating CI failures on #206 — same workflow run shows `macOS-Build-x64` passing (it has the setup) and `macOS-Build` failing identically every time, so the patch source isn't implicated.

## Test plan

- [ ] CI runs `build-c#` on this PR (touches `.github/workflows/**`, not `shared/`, so the `detect-changes` gate skips the C# rebuild) — to actually exercise the fix we need to merge this and re-run #206, or alternatively land both together.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build workflow with required dependencies for C# package management and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->