### PR TITLE
Release v1.2.1

### DIFF
--- a/.github/workflows/dev-pr.yaml
+++ b/.github/workflows/dev-pr.yaml
@@ -16,6 +16,6 @@ jobs:
   dev-pr:
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/dev-pr.yaml@main
     with:
-      app-id: ${{ vars.VERSION_BUMPER_APPID }}
+      client-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:
       private-key: ${{ secrets.VERSION_BUMPER_SECRET }}

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: write # pushes the dev-version bump to main
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump-dev-version.yaml@main
     with:
-      app-id: ${{ vars.VERSION_BUMPER_APPID }}
+      client-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:
       private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
 

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -28,6 +28,6 @@ jobs:
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/release-pr.yaml@main
     with:
       which: ${{ inputs.which }}
-      app-id: ${{ vars.VERSION_BUMPER_APPID }}
+      client-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:
       private-key: ${{ secrets.VERSION_BUMPER_SECRET }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rSharp
 Type: Package
 Title: Accessing .NET from R
-Version: 1.2.0.9001
+Version: 1.2.1
 Authors@R: c(
       person(given = "Open-Systems-Pharmacology Community",
              role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rSharp (development version)
+# rSharp 1.2.1
 
 # rSharp 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rSharp 1.2.1
 
+- Fixed a crash and hang in parallel test suites caused by `R_ReleaseObject` being called from the .NET finalizer thread (#212).
+- Fixed a `GCHandle` leak in the R to .NET argument-marshalling path that caused both the R and .NET heaps to grow with each call (#206).
+
 # rSharp 1.2.0
 
 - Declared `dotnet8` in the `SystemRequirements` field of `DESCRIPTION` (#177).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,13 @@
 # rSharp 1.2.1
 
+## Minor improvements and bug fixes
+
 - Fixed a crash and hang in parallel test suites caused by `R_ReleaseObject` being called from the .NET finalizer thread (#212).
 - Fixed a `GCHandle` leak in the R to .NET argument-marshalling path that caused both the R and .NET heaps to grow with each call (#206).
 
 # rSharp 1.2.0
+
+## Minor improvements and bug fixes
 
 - Declared `dotnet8` in the `SystemRequirements` field of `DESCRIPTION` (#177).
 - Fixed package failing to load on R 4.6 with `undefined symbol: EXTPTR_PTR` by switching the C++ shim to the stable `R_ExternalPtrAddr()` API.
@@ -50,11 +54,10 @@ path containing special characters.
 
 <!-- Section Template
 
-## Minor improvements and bug fixes
-
 ## Breaking Changes
 
 ## Major changes
 
--->
+## Minor improvements and bug fixes
 
+-->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release notes to show **rSharp 1.2.1**.
  * Bumped the package version to **1.2.1**.

* **Chores**
  * Adjusted release automation configuration to use the updated input name consistently across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->