### PR TITLE
Load gracefully when the .NET runtime is absent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rSharp (development version)
 
+- rSharp now installs and loads even when a suitable .NET runtime is absent, instead of failing at load time. A missing runtime is reported when the package is attached and raised with an actionable message on the first call into .NET, which allows the package (and packages depending on it) to be built and checked in environments without .NET.
+
 # rSharp 1.2.1
 
 ## Minor improvements and bug fixes

--- a/R/messages.R
+++ b/R/messages.R
@@ -1,5 +1,31 @@
 messages <- list()
 
+messages$errorMsvcrNotFound <- function() {
+  paste(
+    paste(rSharpEnv$msvcrFileName, "was not found on this Windows system."),
+    "You are probably missing the Visual C++ Redistributable.",
+    "Go to https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170 and download the latest 'Microsoft Visual C++ Redistributable'.",
+    sep = "\n"
+  )
+}
+
+messages$errorDotnetRuntimeNotFound <- function() {
+  paste(
+    paste0(
+      "No .NET ",
+      rSharpEnv$requiredDotnetVersion,
+      " runtime was found."
+    ),
+    "rSharp is installed, but calls into .NET will fail until the runtime is available.",
+    paste0(
+      "Install .NET ",
+      rSharpEnv$requiredDotnetVersion,
+      ": go to https://learn.microsoft.com/en-us/dotnet/core/install/ and follow the installation instructions."
+    ),
+    sep = "\n"
+  )
+}
+
 messages$errorPackageSettingNotFound <- function(settingName, globalEnv) {
   paste0(
     "No global setting with the name '",

--- a/R/rSharp-env.R
+++ b/R/rSharp-env.R
@@ -6,6 +6,11 @@ rSharpEnv <- new.env(parent = emptyenv())
 rSharpEnv$packageName <- "rSharp"
 # Name of the C++ redistributable library
 rSharpEnv$msvcrFileName <- "msvcp140.dll"
+# Major version of the .NET runtime the bundled assemblies target. The runtime
+# check requires this exact major version: the assemblies are built for
+# `net8.0` and their runtimeconfig does not roll forward across major versions,
+# so a higher major (for example .NET 10) is not a valid substitute.
+rSharpEnv$requiredDotnetVersion <- 8L
 # The name of the package
 rSharpEnv$pkgName <- "rSharp"
 

--- a/R/utilities-assembly.R
+++ b/R/utilities-assembly.R
@@ -17,6 +17,7 @@
 #' loadAssembly(f)
 #' }
 loadAssembly <- function(name) {
+  .ensureRuntime()
   result <- .External(
     "rSharp_load_assembly",
     name,

--- a/R/utilities-net-object.R
+++ b/R/utilities-net-object.R
@@ -84,6 +84,7 @@ newObjectFromName <- function(typename, ..., R6objectClass = NetObject) {
 #' # Now we can create a NetObject from the pointer
 #' testObj <- NetObject$new(testPtr)
 newPointerFromName <- function(typename, ...) {
+  .ensureRuntime()
   # Extract the pointer for R6 objects
   args <- .extractPointersFromArgs(list(...))
   # Calling via `do.call` to pass the arguments

--- a/R/utilities-static.R
+++ b/R/utilities-static.R
@@ -73,6 +73,7 @@ getStaticMethods <- function(objOrType, contains = "") {
 #' cTypename <- getRSharpSetting("testCasesTypeName")
 #' callStatic(cTypename, "IsTrue", TRUE)
 callStatic <- function(typename, methodName, ...) {
+  .ensureRuntime()
   # Extract the pointer for R6 objects
   args <- .extractPointersFromArgs(list(...))
   # Calling via `do.call` to pass the arguments

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,38 +1,97 @@
 .onLoad <- function(...) {
   # nocov start
-  # Check for C++ distrib availability
+  # Detect the runtime prerequisites and initialise the .NET domain. Loading the
+  # package must never fail when the runtime is missing: rSharp still has to
+  # install and load on machines and build environments (CRAN check machines,
+  # R-universe builders) that do not have the .NET runtime. When a prerequisite
+  # is missing we record the reason in `rSharpEnv$loadError` and return quietly.
+  # The reason is surfaced to the user in `.onAttach()` and on the first call
+  # into .NET (see `.ensureRuntime()`).
+  rSharpEnv$loadError <- .checkDotnetPrerequisites()
+  if (is.null(rSharpEnv$loadError)) {
+    .loadAndInit()
+  }
+  invisible()
+}
+
+.onAttach <- function(...) {
+  # Surface a missing runtime only when the user explicitly attaches the package
+  # (`library(rSharp)`), using packageStartupMessage() so it can be suppressed.
+  # `.onLoad()` stays silent, as required for a bare namespace load.
+  if (!is.null(rSharpEnv$loadError)) {
+    packageStartupMessage(rSharpEnv$loadError)
+  }
+  invisible()
+} # nocov end
+
+# Checks the runtime prerequisites without side effects. Returns `NULL` when the
+# runtime can be initialised, or a message string describing the missing
+# prerequisite otherwise. Safe to call from both `.onLoad()` and
+# `.ensureRuntime()`.
+.checkDotnetPrerequisites <- function() {
+  # On Windows, the .NET runtime needs the Visual C++ redistributable.
   if (.Platform$OS.type == "windows") {
     if (Sys.which(rSharpEnv$msvcrFileName) == "") {
-      stop(paste(
-        rSharpEnv$msvcrFileName,
-        "was not found on this Windows system.",
-        "You are probably missing the Visual C++ Redistributable.",
-        "Go to https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170 and download the latest 'Microsoft Visual C++ Redistributable'",
-        sep = "\n"
-      ))
+      return(messages$errorMsvcrNotFound())
     }
-  } else {}
-
-  # find installed dotnet runtimes for .NET 8 or higher
-  if (
-    length(grep(
-      "Microsoft.NETCore.App 8",
-      system("dotnet --list-runtimes", intern = TRUE)
-    )) ==
-      0
-  ) {
-    stop(paste(
-      "No suitable dotnet 8 runtime found. ",
-      "Please install dotnet 8: go to  https://learn.microsoft.com/en-us/dotnet/core/install/ and follow installation instructions.",
-      sep = "\n"
-    ))
   }
 
-  # Load the C++ and .NET libraries
+  # Require a runtime whose major version matches the bundled assemblies. A
+  # higher major (for example .NET 10) is not accepted: the assemblies target
+  # `net8.0` and do not roll forward across major versions, so a newer runtime
+  # would pass a naive check and then fail when .NET is actually called.
+  # `dotnet` may be absent entirely, in which case `system()` signals an error
+  # rather than returning output, so guard the call and treat any failure as
+  # "no runtime".
+  runtimes <- tryCatch(
+    suppressWarnings(system("dotnet --list-runtimes", intern = TRUE)),
+    error = function(e) character()
+  )
+  majors <- .dotnetMajorVersions(runtimes)
+  if (!(rSharpEnv$requiredDotnetVersion %in% majors)) {
+    return(messages$errorDotnetRuntimeNotFound())
+  }
+
+  NULL
+}
+
+# Extracts the major versions of the installed `Microsoft.NETCore.App` runtimes
+# from the lines returned by `dotnet --list-runtimes`. Kept pure so it can be
+# unit tested without a .NET runtime present. Each relevant line looks like:
+#   "Microsoft.NETCore.App 8.0.11 [/usr/share/dotnet/shared/...]"
+.dotnetMajorVersions <- function(lines) {
+  if (length(lines) == 0) {
+    return(integer())
+  }
+  appLines <- grep("Microsoft.NETCore.App", lines, value = TRUE)
+  majors <- sub(
+    "^Microsoft\\.NETCore\\.App\\s+([0-9]+)\\..*$",
+    "\\1",
+    appLines
+  )
+  majors <- suppressWarnings(as.integer(majors))
+  majors[!is.na(majors)]
+}
+
+# Ensures the .NET runtime is initialised before a call into .NET. Re-attempts
+# initialisation once (the runtime may have been installed after the package was
+# loaded) and otherwise aborts with the recorded reason, so callers get an
+# actionable error instead of a low-level "PACKAGE not loaded" failure from
+# `.External()`.
+.ensureRuntime <- function() {
+  if (isTRUE(rSharpEnv$runtimeLoaded)) {
+    return(invisible())
+  }
+  rSharpEnv$loadError <- .checkDotnetPrerequisites()
+  if (!is.null(rSharpEnv$loadError)) {
+    stop(rSharpEnv$loadError, call. = FALSE)
+  }
   .loadAndInit()
+  invisible()
 }
 
 .loadAndInit <- function() {
+  # nocov start
   # Path to the folder where the libraries are located
   srcPkgLibPath <- system.file("lib", package = rSharpEnv$packageName)
   nativeLibraryPath <- file.path(
@@ -50,6 +109,12 @@
     enc2native(srcPkgLibPath),
     PACKAGE = rSharpEnv$nativePkgName
   )
+
+  # The native library is loaded and the domain created, so calls into .NET are
+  # possible. Mark the runtime as loaded before the callStatic() below, which
+  # itself routes through `.ensureRuntime()`; setting the flag first avoids
+  # re-entering initialisation.
+  rSharpEnv$runtimeLoaded <- TRUE
 
   # Turn on the the conversion of advanced data types with R.NET.
   invisible(callStatic("ClrFacade.ClrFacade", "SetRDotNet", TRUE))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -44,7 +44,11 @@
   # rather than returning output, so guard the call and treat any failure as
   # "no runtime".
   runtimes <- tryCatch(
-    suppressWarnings(system("dotnet --list-runtimes", intern = TRUE)),
+    suppressWarnings(system(
+      "dotnet --list-runtimes",
+      intern = TRUE,
+      ignore.stderr = TRUE
+    )),
     error = function(e) character()
   )
   majors <- .dotnetMajorVersions(runtimes)

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,0 +1,38 @@
+test_that(".dotnetMajorVersions parses major versions from dotnet output", {
+  lines <- c(
+    "Microsoft.AspNetCore.App 8.0.11 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]",
+    "Microsoft.NETCore.App 8.0.11 [/usr/share/dotnet/shared/Microsoft.NETCore.App]",
+    "Microsoft.NETCore.App 10.0.0 [/usr/share/dotnet/shared/Microsoft.NETCore.App]"
+  )
+  expect_equal(.dotnetMajorVersions(lines), c(8L, 10L))
+})
+
+test_that(".dotnetMajorVersions returns an empty integer vector when nothing matches", {
+  expect_equal(.dotnetMajorVersions(character()), integer())
+  expect_equal(.dotnetMajorVersions(c("", "no runtimes here")), integer())
+})
+
+test_that(".dotnetMajorVersions ignores non NETCore.App runtimes", {
+  lines <- "Microsoft.AspNetCore.App 9.0.0 [/path]"
+  expect_equal(.dotnetMajorVersions(lines), integer())
+})
+
+test_that(".checkDotnetPrerequisites reports a missing runtime when the required major is absent", {
+  # Force the non-Windows branch so the check depends only on the runtime list.
+  local_mocked_bindings(
+    .dotnetMajorVersions = function(...) 10L
+  )
+  withr::local_options(list(rSharp.test_os_type = NULL))
+  skip_on_os("windows")
+  msg <- .checkDotnetPrerequisites()
+  expect_type(msg, "character")
+  expect_match(msg, "No .NET 8 runtime was found", fixed = TRUE)
+})
+
+test_that(".checkDotnetPrerequisites passes when the required major is present", {
+  skip_on_os("windows")
+  local_mocked_bindings(
+    .dotnetMajorVersions = function(...) c(8L, 10L)
+  )
+  expect_null(.checkDotnetPrerequisites())
+})


### PR DESCRIPTION
Loading rSharp currently fails outright when a suitable .NET runtime is not present: `.onLoad()` calls `stop()` when the Visual C++ redistributable (Windows) or a .NET 8 runtime is missing. Because `R CMD INSTALL` and `R CMD check` test-load a package at the end of installation, this makes rSharp uninstallable in any environment without .NET, and it makes every package that imports rSharp uninstallable there too. That blocks building and checking on machines and CI that do not have the runtime, including CRAN check machines and R-universe builders.

This changes loading to degrade gracefully: the package installs and loads without a runtime, reports the problem when it is attached, and raises a clear, actionable error only on the first actual call into .NET.

## Load behaviour

`.onLoad()` no longer stops when a prerequisite is missing. It records the reason in `rSharpEnv$loadError` and returns quietly, so a bare namespace load always succeeds. A new `.onAttach()` surfaces the recorded reason through `packageStartupMessage()` (suppressible), which is the appropriate place for a startup notice. Detection is factored into `.checkDotnetPrerequisites()` (side-effect free) and `.dotnetMajorVersions()` (a pure parser of `dotnet --list-runtimes`), and the `dotnet` call is guarded so an absent `dotnet` is treated as "no runtime" rather than erroring.

## Runtime version

The runtime check requires the exact major version the bundled assemblies target, exposed as `rSharpEnv$requiredDotnetVersion` (currently 8). A higher major (for example .NET 10) is intentionally not accepted: the assemblies target `net8.0` and their runtimeconfig does not roll forward across major versions, so a newer runtime would pass a lax check and then fail when .NET is actually called. When the assemblies move to a newer target, this is a one-line change.

## Calls into .NET

The main entry points (`callStatic()`, `newPointerFromName()`, `loadAssembly()`) now call `.ensureRuntime()` first. It initialises the runtime lazily (re-attempting in case .NET was installed after the package loaded) and otherwise aborts with the recorded reason, so callers get an actionable message instead of a low-level "PACKAGE not loaded" failure from `.External()`. When the runtime is present, behaviour is unchanged.

## Tests

Added coverage for the version parser and the prerequisite check (the runtime-independent logic), using mocked runtime output so both the present and absent cases are exercised without requiring a real .NET installation.

Impact not shown as a reprex: demonstrating it requires toggling between an environment with and without a .NET runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup behavior: the package installs/loads without immediately failing when the .NET runtime is missing; a clear, actionable error is shown when the package is attached or the first .NET call occurs.
  * Added more specific messages for missing Visual C++ components and missing/unsupported .NET runtimes.
* **Bug Fixes**
  * Runtime initialization now re-checks prerequisites before .NET actions and enforces matching the supported major .NET version.
* **Tests**
  * Added tests for parsing `dotnet --list-runtimes` output and prerequisite detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->